### PR TITLE
Fix #3: warn when webhook_secret is not an env variable

### DIFF
--- a/src/DependencyInjection/WebhookSecretEnvCheckPass.php
+++ b/src/DependencyInjection/WebhookSecretEnvCheckPass.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ilbee\Okta\Event\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+final class WebhookSecretEnvCheckPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->hasParameter('okta_event.webhook_secret')) {
+            return;
+        }
+
+        $value = $container->getParameter('okta_event.webhook_secret');
+
+        if (\is_string($value) && !str_starts_with($value, '%env(')) {
+            trigger_error(
+                'okta_event.webhook_secret contains a plaintext secret. '
+                .'Use an environment variable instead: webhook_secret: \'%env(OKTA_WEBHOOK_SECRET)%\'',
+                \E_USER_WARNING,
+            );
+        }
+    }
+}

--- a/src/OktaEventBundle.php
+++ b/src/OktaEventBundle.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Ilbee\Okta\Event;
 
+use Ilbee\Okta\Event\DependencyInjection\WebhookSecretEnvCheckPass;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Configurator\DefinitionConfigurator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -13,6 +14,13 @@ use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 
 final class OktaEventBundle extends AbstractBundle
 {
+    public function build(ContainerBuilder $container): void
+    {
+        parent::build($container);
+
+        $container->addCompilerPass(new WebhookSecretEnvCheckPass());
+    }
+
     /**
      * Defines the bundle's configuration tree.
      */

--- a/tests/DependencyInjection/WebhookSecretEnvCheckPassTest.php
+++ b/tests/DependencyInjection/WebhookSecretEnvCheckPassTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ilbee\Okta\Event\Tests\DependencyInjection;
+
+use Ilbee\Okta\Event\DependencyInjection\WebhookSecretEnvCheckPass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class WebhookSecretEnvCheckPassTest extends TestCase
+{
+    public function testWarnsOnPlaintextSecret(): void
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('okta_event.webhook_secret', 'my_plaintext_secret');
+
+        $pass = new WebhookSecretEnvCheckPass();
+
+        $warning = null;
+        set_error_handler(static function (int $errno, string $errstr) use (&$warning): bool {
+            $warning = $errstr;
+
+            return true;
+        }, \E_USER_WARNING);
+
+        try {
+            $pass->process($container);
+        } finally {
+            restore_error_handler();
+        }
+
+        self::assertNotNull($warning);
+        self::assertStringContainsString('okta_event.webhook_secret contains a plaintext secret', $warning);
+    }
+
+    public function testNoWarningWithEnvVariable(): void
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('okta_event.webhook_secret', '%env(OKTA_WEBHOOK_SECRET)%');
+
+        $pass = new WebhookSecretEnvCheckPass();
+
+        $warned = false;
+        set_error_handler(static function () use (&$warned): bool {
+            $warned = true;
+
+            return true;
+        }, \E_USER_WARNING);
+
+        try {
+            $pass->process($container);
+        } finally {
+            restore_error_handler();
+        }
+
+        self::assertFalse($warned);
+    }
+
+    public function testNoWarningWhenParameterMissing(): void
+    {
+        $container = new ContainerBuilder();
+
+        $pass = new WebhookSecretEnvCheckPass();
+
+        $pass->process($container);
+
+        $this->addToAssertionCount(1);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a `WebhookSecretEnvCheckPass` compiler pass that emits a `E_USER_WARNING` at container compile time if `okta_event.webhook_secret` does not use `%env(...)%` notation
- Prevents plaintext secrets from being silently serialized into `var/cache/` PHP files
- Registered in `OktaEventBundle::build()`

## Test plan
- [x] Unit tests for plaintext warning, env variable (no warning), and missing parameter (no warning)
- [x] PHPStan level 10 passes
- [x] Full test suite passes