### PR TITLE
Fix #4: require X-Auth-Token on GET verification endpoint

### DIFF
--- a/src/Controller/OktaWebhookController.php
+++ b/src/Controller/OktaWebhookController.php
@@ -44,10 +44,6 @@ final readonly class OktaWebhookController
 
     public function __invoke(Request $request): Response
     {
-        if ($request->isMethod('GET')) {
-            return $this->handleVerification($request);
-        }
-
         $authToken = $request->headers->get('X-Auth-Token');
         if (!$authToken) {
             $this->logger->error('X-Auth-Token header is missing.');
@@ -59,6 +55,10 @@ final readonly class OktaWebhookController
             $this->logger->error('Invalid X-Auth-Token.');
 
             return new Response('Invalid token.', Response::HTTP_FORBIDDEN);
+        }
+
+        if ($request->isMethod('GET')) {
+            return $this->handleVerification($request);
         }
 
         $body = $request->getContent();

--- a/tests/Controller/OktaWebhookControllerTest.php
+++ b/tests/Controller/OktaWebhookControllerTest.php
@@ -32,6 +32,27 @@ class OktaWebhookControllerTest extends WebTestCase
         'displayName' => 'Admin User',
     ];
 
+    public function testGetVerificationFailsWithMissingAuthToken(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', '/okta/webhook', [], [], [
+            'HTTP_x-okta-verification-challenge' => 'some-random-challenge-string',
+        ]);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+    }
+
+    public function testGetVerificationFailsWithInvalidAuthToken(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', '/okta/webhook', [], [], [
+            'HTTP_X-Auth-Token' => 'wrong_secret',
+            'HTTP_x-okta-verification-challenge' => 'some-random-challenge-string',
+        ]);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+    }
+
     public function testGetVerificationChallengeSuccess(): void
     {
         $client = static::createClient();
@@ -42,7 +63,10 @@ class OktaWebhookControllerTest extends WebTestCase
             '/okta/webhook',
             [],
             [],
-            ['HTTP_x-okta-verification-challenge' => $challenge]
+            [
+                'HTTP_X-Auth-Token' => 'test_secret',
+                'HTTP_x-okta-verification-challenge' => $challenge,
+            ]
         );
 
         $this->assertResponseIsSuccessful();
@@ -60,7 +84,9 @@ class OktaWebhookControllerTest extends WebTestCase
     public function testGetVerificationFailsWhenHeaderIsMissing(): void
     {
         $client = static::createClient();
-        $client->request('GET', '/okta/webhook');
+        $client->request('GET', '/okta/webhook', [], [], [
+            'HTTP_X-Auth-Token' => 'test_secret',
+        ]);
 
         $this->assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
     }
@@ -69,6 +95,7 @@ class OktaWebhookControllerTest extends WebTestCase
     {
         $client = static::createClient();
         $client->request('GET', '/okta/webhook', [], [], [
+            'HTTP_X-Auth-Token' => 'test_secret',
             'HTTP_x-okta-verification-challenge' => 'invalid challenge with spaces!',
         ]);
 

--- a/tests/Controller/OktaWebhookSecurityTest.php
+++ b/tests/Controller/OktaWebhookSecurityTest.php
@@ -29,6 +29,7 @@ class OktaWebhookSecurityTest extends WebTestCase
     {
         $client = static::createClient();
         $client->request('GET', '/okta/webhook', [], [], [
+            'HTTP_X-Auth-Token' => 'test_secret',
             'HTTP_x-okta-verification-challenge' => 'some-valid-challenge',
         ]);
 


### PR DESCRIPTION
## Summary
- Move `X-Auth-Token` validation before GET/POST routing so the verification endpoint requires authentication
- Add tests for unauthenticated and invalid-token GET requests (400 and 403)
- Update existing verification tests to include auth token

Closes #4

## Test plan
- [x] All 114 tests pass
- [x] PHPStan level 10 clean
- [ ] Verify Okta webhook re-verification still works with the token