### PR TITLE
Fix #5: validate Content-Type and pre-check Content-Length

### DIFF
--- a/src/Controller/OktaWebhookController.php
+++ b/src/Controller/OktaWebhookController.php
@@ -61,6 +61,23 @@ final readonly class OktaWebhookController
             return $this->handleVerification($request);
         }
 
+        $contentType = $request->headers->get('Content-Type', '');
+        if (!str_starts_with($contentType, 'application/json')) {
+            $this->logger->warning('Unsupported Content-Type.', ['content_type' => $contentType]);
+
+            return new Response('Unsupported Media Type.', Response::HTTP_UNSUPPORTED_MEDIA_TYPE);
+        }
+
+        $contentLength = $request->headers->get('Content-Length');
+        if (null !== $contentLength && (int) $contentLength > $this->maxPayloadSize) {
+            $this->logger->warning('Content-Length exceeds maximum allowed size.', [
+                'content_length' => (int) $contentLength,
+                'max' => $this->maxPayloadSize,
+            ]);
+
+            return new Response('Payload too large.', Response::HTTP_REQUEST_ENTITY_TOO_LARGE);
+        }
+
         $body = $request->getContent();
         if (\strlen($body) > $this->maxPayloadSize) {
             $this->logger->warning('Payload exceeds maximum allowed size.', [

--- a/tests/Controller/OktaWebhookControllerTest.php
+++ b/tests/Controller/OktaWebhookControllerTest.php
@@ -143,7 +143,7 @@ class OktaWebhookControllerTest extends WebTestCase
             '/okta/webhook',
             [],
             [],
-            ['HTTP_X-Auth-Token' => 'test_secret'],
+            ['HTTP_X-Auth-Token' => 'test_secret', 'CONTENT_TYPE' => 'application/json'],
             '{"this is not valid json'
         );
 
@@ -160,7 +160,7 @@ class OktaWebhookControllerTest extends WebTestCase
             '/okta/webhook',
             [],
             [],
-            ['HTTP_X-Auth-Token' => 'test_secret'],
+            ['HTTP_X-Auth-Token' => 'test_secret', 'CONTENT_TYPE' => 'application/json'],
             $payload
         );
 
@@ -178,7 +178,7 @@ class OktaWebhookControllerTest extends WebTestCase
             '/okta/webhook',
             [],
             [],
-            ['HTTP_X-Auth-Token' => 'test_secret'],
+            ['HTTP_X-Auth-Token' => 'test_secret', 'CONTENT_TYPE' => 'application/json'],
             $payload
         );
 
@@ -195,7 +195,7 @@ class OktaWebhookControllerTest extends WebTestCase
             '/okta/webhook',
             [],
             [],
-            ['HTTP_X-Auth-Token' => 'test_secret'],
+            ['HTTP_X-Auth-Token' => 'test_secret', 'CONTENT_TYPE' => 'application/json'],
             $payload
         );
 
@@ -212,7 +212,7 @@ class OktaWebhookControllerTest extends WebTestCase
             '/okta/webhook',
             [],
             [],
-            ['HTTP_X-Auth-Token' => 'test_secret'],
+            ['HTTP_X-Auth-Token' => 'test_secret', 'CONTENT_TYPE' => 'application/json'],
             $payload
         );
 
@@ -229,7 +229,7 @@ class OktaWebhookControllerTest extends WebTestCase
             '/okta/webhook',
             [],
             [],
-            ['HTTP_X-Auth-Token' => 'test_secret'],
+            ['HTTP_X-Auth-Token' => 'test_secret', 'CONTENT_TYPE' => 'application/json'],
             $payload
         );
 
@@ -246,7 +246,7 @@ class OktaWebhookControllerTest extends WebTestCase
             '/okta/webhook',
             [],
             [],
-            ['HTTP_X-Auth-Token' => 'test_secret'],
+            ['HTTP_X-Auth-Token' => 'test_secret', 'CONTENT_TYPE' => 'application/json'],
             $payload
         );
 
@@ -263,7 +263,7 @@ class OktaWebhookControllerTest extends WebTestCase
             '/okta/webhook',
             [],
             [],
-            ['HTTP_X-Auth-Token' => 'test_secret'],
+            ['HTTP_X-Auth-Token' => 'test_secret', 'CONTENT_TYPE' => 'application/json'],
             $payload
         );
 
@@ -280,7 +280,7 @@ class OktaWebhookControllerTest extends WebTestCase
             '/okta/webhook',
             [],
             [],
-            ['HTTP_X-Auth-Token' => 'test_secret'],
+            ['HTTP_X-Auth-Token' => 'test_secret', 'CONTENT_TYPE' => 'application/json'],
             $payload
         );
 
@@ -297,7 +297,7 @@ class OktaWebhookControllerTest extends WebTestCase
             '/okta/webhook',
             [],
             [],
-            ['HTTP_X-Auth-Token' => 'test_secret'],
+            ['HTTP_X-Auth-Token' => 'test_secret', 'CONTENT_TYPE' => 'application/json'],
             $payload
         );
 
@@ -314,7 +314,7 @@ class OktaWebhookControllerTest extends WebTestCase
             '/okta/webhook',
             [],
             [],
-            ['HTTP_X-Auth-Token' => 'test_secret'],
+            ['HTTP_X-Auth-Token' => 'test_secret', 'CONTENT_TYPE' => 'application/json'],
             $payload
         );
 
@@ -330,7 +330,7 @@ class OktaWebhookControllerTest extends WebTestCase
             '/okta/webhook',
             [],
             [],
-            ['HTTP_X-Auth-Token' => 'test_secret'],
+            ['HTTP_X-Auth-Token' => 'test_secret', 'CONTENT_TYPE' => 'application/json'],
             '{"data":{"events":[]}}'
         );
 
@@ -364,7 +364,7 @@ class OktaWebhookControllerTest extends WebTestCase
             '/okta/webhook',
             [],
             [],
-            ['HTTP_X-Auth-Token' => 'test_secret'],
+            ['HTTP_X-Auth-Token' => 'test_secret', 'CONTENT_TYPE' => 'application/json'],
             $payload
         );
 
@@ -393,7 +393,7 @@ class OktaWebhookControllerTest extends WebTestCase
             '/okta/webhook',
             [],
             [],
-            ['HTTP_X-Auth-Token' => 'test_secret'],
+            ['HTTP_X-Auth-Token' => 'test_secret', 'CONTENT_TYPE' => 'application/json'],
             $payload
         );
 
@@ -442,7 +442,7 @@ class OktaWebhookControllerTest extends WebTestCase
             '/okta/webhook',
             [],
             [],
-            ['HTTP_X-Auth-Token' => 'test_secret'],
+            ['HTTP_X-Auth-Token' => 'test_secret', 'CONTENT_TYPE' => 'application/json'],
             $payload
         );
 
@@ -470,7 +470,7 @@ class OktaWebhookControllerTest extends WebTestCase
             '/okta/webhook',
             [],
             [],
-            ['HTTP_X-Auth-Token' => 'test_secret'],
+            ['HTTP_X-Auth-Token' => 'test_secret', 'CONTENT_TYPE' => 'application/json'],
             $payload
         );
 
@@ -498,7 +498,7 @@ class OktaWebhookControllerTest extends WebTestCase
             '/okta/webhook',
             [],
             [],
-            ['HTTP_X-Auth-Token' => 'test_secret'],
+            ['HTTP_X-Auth-Token' => 'test_secret', 'CONTENT_TYPE' => 'application/json'],
             $payload
         );
 
@@ -526,7 +526,7 @@ class OktaWebhookControllerTest extends WebTestCase
             '/okta/webhook',
             [],
             [],
-            ['HTTP_X-Auth-Token' => 'test_secret'],
+            ['HTTP_X-Auth-Token' => 'test_secret', 'CONTENT_TYPE' => 'application/json'],
             $payload
         );
 
@@ -558,7 +558,7 @@ class OktaWebhookControllerTest extends WebTestCase
             '/okta/webhook',
             [],
             [],
-            ['HTTP_X-Auth-Token' => 'test_secret'],
+            ['HTTP_X-Auth-Token' => 'test_secret', 'CONTENT_TYPE' => 'application/json'],
             $payload
         );
 
@@ -587,7 +587,7 @@ class OktaWebhookControllerTest extends WebTestCase
             '/okta/webhook',
             [],
             [],
-            ['HTTP_X-Auth-Token' => 'test_secret'],
+            ['HTTP_X-Auth-Token' => 'test_secret', 'CONTENT_TYPE' => 'application/json'],
             $payload
         );
 
@@ -614,7 +614,7 @@ class OktaWebhookControllerTest extends WebTestCase
             '/okta/webhook',
             [],
             [],
-            ['HTTP_X-Auth-Token' => 'test_secret'],
+            ['HTTP_X-Auth-Token' => 'test_secret', 'CONTENT_TYPE' => 'application/json'],
             $payload
         );
 

--- a/tests/Controller/OktaWebhookSecurityTest.php
+++ b/tests/Controller/OktaWebhookSecurityTest.php
@@ -36,6 +36,58 @@ class OktaWebhookSecurityTest extends WebTestCase
         $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
     }
 
+    public function testPostWithWrongContentTypeReturns415(): void
+    {
+        $client = static::createClient();
+
+        $client->request(
+            'POST',
+            '/okta/webhook',
+            [],
+            [],
+            ['HTTP_X-Auth-Token' => 'test_secret', 'CONTENT_TYPE' => 'text/plain'],
+            '{"data":{"events":[]}}'
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNSUPPORTED_MEDIA_TYPE);
+    }
+
+    public function testPostWithMissingContentTypeReturns415(): void
+    {
+        $client = static::createClient();
+
+        $client->request(
+            'POST',
+            '/okta/webhook',
+            [],
+            [],
+            ['HTTP_X-Auth-Token' => 'test_secret'],
+            '{"data":{"events":[]}}'
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNSUPPORTED_MEDIA_TYPE);
+    }
+
+    public function testContentLengthExceedingMaxIsRejectedBeforeReadingBody(): void
+    {
+        $client = static::createClient();
+
+        $client->request(
+            'POST',
+            '/okta/webhook',
+            [],
+            [],
+            [
+                'HTTP_X-Auth-Token' => 'test_secret',
+                'CONTENT_TYPE' => 'application/json',
+                'HTTP_Content-Length' => '9999',
+            ],
+            '{"data":{"events":[]}}'
+        );
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_REQUEST_ENTITY_TOO_LARGE);
+    }
+
     public function testPayloadExceedingMaxSizeIsRejected(): void
     {
         $client = static::createClient();
@@ -48,7 +100,7 @@ class OktaWebhookSecurityTest extends WebTestCase
             '/okta/webhook',
             [],
             [],
-            ['HTTP_X-Auth-Token' => 'test_secret'],
+            ['HTTP_X-Auth-Token' => 'test_secret', 'CONTENT_TYPE' => 'application/json'],
             $oversizedPayload
         );
 
@@ -85,7 +137,7 @@ class OktaWebhookSecurityTest extends WebTestCase
             '/okta/webhook',
             [],
             [],
-            ['HTTP_X-Auth-Token' => 'test_secret'],
+            ['HTTP_X-Auth-Token' => 'test_secret', 'CONTENT_TYPE' => 'application/json'],
             $payload
         );
 
@@ -130,7 +182,7 @@ class OktaWebhookSecurityTest extends WebTestCase
             '/okta/webhook',
             [],
             [],
-            ['HTTP_X-Auth-Token' => 'test_secret'],
+            ['HTTP_X-Auth-Token' => 'test_secret', 'CONTENT_TYPE' => 'application/json'],
             $payload
         );
 
@@ -149,7 +201,7 @@ class OktaWebhookSecurityTest extends WebTestCase
             '/okta/webhook',
             [],
             [],
-            ['HTTP_X-Auth-Token' => 'test_secret'],
+            ['HTTP_X-Auth-Token' => 'test_secret', 'CONTENT_TYPE' => 'application/json'],
             '{not valid json'
         );
 
@@ -201,7 +253,7 @@ class OktaWebhookSecurityTest extends WebTestCase
             '/okta/webhook',
             [],
             [],
-            ['HTTP_X-Auth-Token' => 'test_secret'],
+            ['HTTP_X-Auth-Token' => 'test_secret', 'CONTENT_TYPE' => 'application/json'],
             $payload
         );
 


### PR DESCRIPTION
## Summary
- Reject POST requests without `application/json` Content-Type with 415 Unsupported Media Type
- Pre-check `Content-Length` header before reading the full body to avoid buffering oversized payloads (returns 413 early)
- All existing POST tests updated to send `CONTENT_TYPE: application/json`

## Test plan
- [x] `testPostWithWrongContentTypeReturns415` — text/plain → 415
- [x] `testPostWithMissingContentTypeReturns415` — no Content-Type → 415
- [x] `testContentLengthExceedingMaxIsRejectedBeforeReadingBody` — oversized Content-Length → 413
- [x] All existing tests pass with `CONTENT_TYPE` header

Closes #5