### PR TITLE
Fix #6: sanitize log fields to prevent log injection

### DIFF
--- a/src/Controller/OktaWebhookController.php
+++ b/src/Controller/OktaWebhookController.php
@@ -7,6 +7,7 @@ namespace Ilbee\Okta\Event\Controller;
 use Ilbee\Okta\Event\DTO\OktaWebhookPayload;
 use Ilbee\Okta\Event\Event\GenericOktaEvent;
 use Ilbee\Okta\Event\Event\UserLifecycle\OktaUserLifecycleEvent;
+use Ilbee\Okta\Event\Service\LogSanitizer;
 use Ilbee\Okta\Event\Service\OktaEventIdStoreInterface;
 use Ilbee\Okta\Event\Service\OktaEventMapper;
 use Ilbee\Okta\Event\Service\OktaEventRegistry;
@@ -25,8 +26,6 @@ final readonly class OktaWebhookController
         OktaUserLifecycleEvent::DEACTIVATE,
         OktaUserLifecycleEvent::SUSPEND,
     ];
-
-    private const MAX_LOG_FIELD_LENGTH = 255;
 
     public function __construct(
         private SerializerInterface $serializer,
@@ -127,7 +126,7 @@ final readonly class OktaWebhookController
         foreach ($events as $oktaEvent) {
             if (null !== $oktaEvent->uuid && $this->eventIdStore->has($oktaEvent->uuid)) {
                 $this->logger->info('Skipping duplicate event.', [
-                    'uuid' => $this->truncateLogField($oktaEvent->uuid),
+                    'uuid' => LogSanitizer::sanitize($oktaEvent->uuid),
                 ]);
 
                 continue;
@@ -143,7 +142,7 @@ final readonly class OktaWebhookController
                     $typedEvent = $this->eventMapper->map($oktaEvent);
                 } catch (\Throwable $e) {
                     $this->logger->warning('Failed to map Okta event.', [
-                        'eventType' => $this->truncateLogField($oktaEvent->eventType),
+                        'eventType' => LogSanitizer::sanitize($oktaEvent->eventType),
                         'exception' => $e,
                     ]);
                     $typedEvent = null;
@@ -173,7 +172,7 @@ final readonly class OktaWebhookController
             // 4. Fallback: dispatch GenericOktaEvent for completely unknown events
             if (null === $individualEvent && null === $groupEvent && !$this->eventMapper->supports($oktaEvent->eventType)) {
                 $this->logger->info('Dispatching generic event for unknown Okta event type.', [
-                    'eventType' => $this->truncateLogField($oktaEvent->eventType),
+                    'eventType' => LogSanitizer::sanitize($oktaEvent->eventType),
                 ]);
                 $this->eventDispatcher->dispatch(new GenericOktaEvent($oktaEvent));
             }
@@ -199,12 +198,4 @@ final readonly class OktaWebhookController
         return new JsonResponse(['verification' => $challenge]);
     }
 
-    private function truncateLogField(string $value): string
-    {
-        if (mb_strlen($value) > self::MAX_LOG_FIELD_LENGTH) {
-            return mb_substr($value, 0, self::MAX_LOG_FIELD_LENGTH).'...';
-        }
-
-        return $value;
-    }
 }

--- a/src/Controller/OktaWebhookController.php
+++ b/src/Controller/OktaWebhookController.php
@@ -197,5 +197,4 @@ final readonly class OktaWebhookController
 
         return new JsonResponse(['verification' => $challenge]);
     }
-
 }

--- a/src/Service/LogSanitizer.php
+++ b/src/Service/LogSanitizer.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ilbee\Okta\Event\Service;
+
+final class LogSanitizer
+{
+    private const MAX_FIELD_LENGTH = 255;
+
+    public static function sanitize(string $value, int $maxLength = self::MAX_FIELD_LENGTH): string
+    {
+        // Strip control characters (newlines, carriage returns, ANSI escapes, etc.)
+        $value = preg_replace('/[\x00-\x1F\x7F]/', '', $value) ?? $value;
+
+        if (mb_strlen($value) > $maxLength) {
+            return mb_substr($value, 0, $maxLength) . '...';
+        }
+
+        return $value;
+    }
+}

--- a/src/Service/LogSanitizer.php
+++ b/src/Service/LogSanitizer.php
@@ -14,7 +14,7 @@ final class LogSanitizer
         $value = preg_replace('/[\x00-\x1F\x7F]/', '', $value) ?? $value;
 
         if (mb_strlen($value) > $maxLength) {
-            return mb_substr($value, 0, $maxLength) . '...';
+            return mb_substr($value, 0, $maxLength).'...';
         }
 
         return $value;

--- a/src/Service/OktaEventMapper.php
+++ b/src/Service/OktaEventMapper.php
@@ -20,7 +20,6 @@ use Ilbee\Okta\Event\Event\UserLifecycle\OktaUserProfileUpdatedEvent;
 use Ilbee\Okta\Event\Event\UserLifecycle\OktaUserReactivatedEvent;
 use Ilbee\Okta\Event\Event\UserLifecycle\OktaUserSuspendedEvent;
 use Ilbee\Okta\Event\Event\UserLifecycle\OktaUserUnsuspendedEvent;
-use Ilbee\Okta\Event\Service\LogSanitizer;
 use Psr\Log\LoggerInterface;
 
 final readonly class OktaEventMapper

--- a/src/Service/OktaEventMapper.php
+++ b/src/Service/OktaEventMapper.php
@@ -20,6 +20,7 @@ use Ilbee\Okta\Event\Event\UserLifecycle\OktaUserProfileUpdatedEvent;
 use Ilbee\Okta\Event\Event\UserLifecycle\OktaUserReactivatedEvent;
 use Ilbee\Okta\Event\Event\UserLifecycle\OktaUserSuspendedEvent;
 use Ilbee\Okta\Event\Event\UserLifecycle\OktaUserUnsuspendedEvent;
+use Ilbee\Okta\Event\Service\LogSanitizer;
 use Psr\Log\LoggerInterface;
 
 final readonly class OktaEventMapper
@@ -77,7 +78,7 @@ final readonly class OktaEventMapper
 
         if (null === $userTarget) {
             $this->logger->warning('No User target found in event.', [
-                'eventType' => $oktaEvent->eventType,
+                'eventType' => LogSanitizer::sanitize($oktaEvent->eventType),
             ]);
 
             return null;
@@ -85,8 +86,8 @@ final readonly class OktaEventMapper
 
         if (!filter_var($userTarget->alternateId, \FILTER_VALIDATE_EMAIL)) {
             $this->logger->warning('Skipping target with non-email alternateId.', [
-                'alternateId' => mb_substr($userTarget->alternateId, 0, 255),
-                'eventType' => mb_substr($oktaEvent->eventType, 0, 255),
+                'alternateId' => LogSanitizer::sanitize($userTarget->alternateId),
+                'eventType' => LogSanitizer::sanitize($oktaEvent->eventType),
             ]);
 
             return null;
@@ -121,7 +122,7 @@ final readonly class OktaEventMapper
 
         if (null === $groupTarget) {
             $this->logger->warning('No UserGroup target found in group membership event.', [
-                'eventType' => $oktaEvent->eventType,
+                'eventType' => LogSanitizer::sanitize($oktaEvent->eventType),
             ]);
 
             return null;
@@ -139,7 +140,7 @@ final readonly class OktaEventMapper
 
         if (null === $appTarget) {
             $this->logger->warning('No AppInstance target found in app assignment event.', [
-                'eventType' => $oktaEvent->eventType,
+                'eventType' => LogSanitizer::sanitize($oktaEvent->eventType),
             ]);
 
             return null;

--- a/tests/Service/LogSanitizerTest.php
+++ b/tests/Service/LogSanitizerTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ilbee\Okta\Event\Tests\Service;
+
+use Ilbee\Okta\Event\Service\LogSanitizer;
+use PHPUnit\Framework\TestCase;
+
+class LogSanitizerTest extends TestCase
+{
+    public function testStripsNewlines(): void
+    {
+        self::assertSame('fakeline1fakeline2', LogSanitizer::sanitize("fakeline1\nfakeline2"));
+    }
+
+    public function testStripsCarriageReturns(): void
+    {
+        self::assertSame('fakeline1fakeline2', LogSanitizer::sanitize("fakeline1\r\nfakeline2"));
+    }
+
+    public function testStripsAnsiEscapeSequences(): void
+    {
+        self::assertSame('before[31mredafter', LogSanitizer::sanitize("before\e[31mredafter"));
+    }
+
+    public function testStripsNullBytes(): void
+    {
+        self::assertSame('ab', LogSanitizer::sanitize("a\x00b"));
+    }
+
+    public function testTruncatesLongValues(): void
+    {
+        $long = str_repeat('a', 300);
+        $result = LogSanitizer::sanitize($long);
+
+        self::assertSame(258, mb_strlen($result)); // 255 + '...'
+        self::assertStringEndsWith('...', $result);
+    }
+
+    public function testCustomMaxLength(): void
+    {
+        $result = LogSanitizer::sanitize('abcdefghij', 5);
+
+        self::assertSame('abcde...', $result);
+    }
+
+    public function testLeavesCleanStringUntouched(): void
+    {
+        self::assertSame('clean-value_123', LogSanitizer::sanitize('clean-value_123'));
+    }
+}


### PR DESCRIPTION
## Summary
- Extract `LogSanitizer::sanitize()` that strips control characters (newlines, carriage returns, ANSI escapes, null bytes) and truncates to 255 chars
- Replace `truncateLogField()` in `OktaWebhookController` with `LogSanitizer::sanitize()`
- Sanitize all `eventType` and `alternateId` log context values in `OktaEventMapper`

## Test plan
- [x] `LogSanitizerTest` — 7 cases: newlines, CR+LF, ANSI escapes, null bytes, truncation, custom max length, clean passthrough
- [x] All 52 existing controller + service tests pass

Closes #6